### PR TITLE
Fix `device_type` 0 evaluates to false

### DIFF
--- a/lib/part/players.js
+++ b/lib/part/players.js
@@ -44,7 +44,7 @@ Players.prototype.create = function (params, callback) {
     if (!params.app_id) {
         return callback(new Error('OneSignal Error (app_id parameter required)'));
     }
-    if (!params.device_type) {
+    if (typeof params.device_type === 'undefined') {
         return callback(new Error('OneSignal Error (device_type parameter required)'));
     }
     this.request('POST', ['players'], undefined, params, callback, function (res, result) { 


### PR DESCRIPTION
If `device_type` is set to `0` this evaluates to `false` thus isn't usable.
