### PR TITLE
Fixed ReferenceError on NodeJS v6.4.0

### DIFF
--- a/lib/part/client.js
+++ b/lib/part/client.js
@@ -48,8 +48,8 @@ var Client = exports.Client = function (options) {
 //
 Client.prototype.request = function (method, uri, authKey /* variable arguments */ ) {  
     var args = Array.prototype.slice.call(arguments),
-        success = args.pop();
-        callback = args.pop();
+        success = args.pop(),
+        callback = args.pop(),
         body = typeof args[args.length - 1] === 'object' && ! Array.isArray(args[args.length - 1]) && args.pop(),
         proxy = this.options.get('proxy');        
 


### PR DESCRIPTION
In my environment, using node-onesignal-api would throw a ReferenceError message:

```
ReferenceError: callback is not defined
    at Client.request (node_modules/node-opensignal-api/lib/part/client.js:52:18)
    at Notifications.create(node_modules/node-opensignal-api/lib/part/notifications.js:85:
10)
```

And this was caused by a typo in the variable declarations of the `Client.prototype.request` method, that was probably being ignored in older versions of NodeJS.

My NodeJS version is 6.4.0
Edit: my apologies, I was running my app with --use_strict flag. Still, nice to have strict mode support.
